### PR TITLE
Simple layout for Sign Up

### DIFF
--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,10 +1,66 @@
+import { Button } from "@/components/ui/button";
+
+
+const inputBox = [
+  <form action="/Submit">
+          <input type="text" className="rounded border w-1/2 flex items-center"></input>
+        </form>
+];
+
+
 export default function Signup()
 {
   return (
-    <div className='p-0 pt-28'>
-      <center>
-      Signup page
-      </center>
-    </div>    
+    <div className="p-8 pt-28 gap-y-6 flex flex-col">
+      <div className="mt-12 text-sm font-extrabold text-neutral-500">Home / SignUp Page</div>
+      <div className="mb-12 p-10">
+        <h3 className="text-3xl flex items-center font-bold">Join the club.</h3>
+        <p className="text-neutral-800 sm:text-l md:text-1xl font-small mb-4 dark:text-neutral-600 ">
+         A club member will reach out and assist you in your on boarding after the submition of your club application
+        </p>
+    
+    <p className="p-3 flex items-center">First and last name</p>
+        {inputBox}
+
+        <p className="p-3">SWC email</p>
+        {inputBox}
+
+        <p className="p-3">Major</p>
+        {inputBox}
+
+        <p className="p-3">Goal transfer school</p>
+        {inputBox}
+
+        <p className="p-3">Area of interest</p>
+        <select id="options" name="options" defaultValue="">
+          <option value="" disabled>
+            Select an option
+          </option>
+          <option value="option1">Web Development</option>
+          <option value="option2">Game Development</option>
+          <option value="option3">Machine Learning</option>
+          <option value="option4">Cyber Security</option>
+          <option value="option5">Other</option>
+        </select>
+        
+        <p className="p-3">How much programming experience do you have?</p>
+        {inputBox}
+
+        <p className="p-3">Expectaions?What do you hope to gain from joining the club?</p>
+        {inputBox}
+
+        <p className="p-3">Addition comments or questions?</p>
+        {inputBox}
+
+        <div className="flex items-center justify-center pt-12">
+             <Button variant="outline">
+              Submit
+             </Button>
+           </div>
+      </div>
+      
+    </div>   
+
+
   )
 }


### PR DESCRIPTION
Kelvin and I were able to make a basic layout of the sign up page, its not 1 to 1 according to the figma file but its a start.
-text/text boxes are not centered
-light mode could be adjusted for better visibility 
we were thinking to make an issue on github to enhance and make the signup page prettier 
<img width="1440" alt="Screen Shot 2024-01-22 at 11 09 38 PM" src="https://github.com/SWC-Software-Engineering-Club/SWE-Club-Website/assets/155923948/a5fe4779-3205-48cb-8302-2e2ae4ce4d99">
<img width="1440" alt="Screen Shot 2024-01-22 at 11 09 46 PM" src="https://github.com/SWC-Software-Engineering-Club/SWE-Club-Website/assets/155923948/c8592e52-9729-4d10-af05-89811ca840a8">
