### PR TITLE
Updated link-hub-ui.tsx

### DIFF
--- a/app/link-hub/_component/link-hub-ui.tsx
+++ b/app/link-hub/_component/link-hub-ui.tsx
@@ -16,7 +16,7 @@ const linkData = [
   },
   {
     title: "Discord",
-    route: "https://discord.gg/FcJkRhY2",
+    route: "https://discord.gg/A3quvX5Q",
     icon: MessageCircleCode
   },
   // {


### PR DESCRIPTION
Temporary Discord link has been swapped out for the new permanent invite link which never expires 